### PR TITLE
Rename quaternion test for pytest discovery

### DIFF
--- a/geometricalgebra/tests/test_versor.py
+++ b/geometricalgebra/tests/test_versor.py
@@ -254,7 +254,7 @@ def test_motor_from_and_to_screw2():
     assert np.allclose(reference, result)
 
 
-def from_and_to_quaternion():
+def test_from_and_to_quaternion():
     quaternion = [1, 2, 3, 4]
     versor = cga3d.Vector.from_quaternion(quaternion)
     result = versor.to_quaternion()


### PR DESCRIPTION
## Summary
- fix quaternion conversion test name so pytest finds it

## Testing
- `pytest geometricalgebra/tests/test_versor.py::test_from_and_to_quaternion -vv` *(fails: command not found)*